### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build docker.pkg.github.com/sboardwell/dockerfile-for-dev-ci-image/dev-ci
-        uses: elgohr/Publish-Docker-Github-Action@2.19
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: dev-ci
           tag_semver: true


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore